### PR TITLE
Pointing reusable to master branch

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   autoupdate:
-    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@MLO-10
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
     with:
       upstream_repository: https://github.com/langgenius/dify
       upstream_tag_regex: '\d+\..*'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/auto-pr.yml` file. The change updates the workflow to use the `master` branch instead of the `MLO-10` branch.

* [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1L11-R11): Changed the branch reference from `MLO-10` to `master` in the `uses` attribute.